### PR TITLE
Break char set

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "lint": "eslint resources/assets/js --ext=js,vue",
     "dev": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "watch": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "watch": "yarn dev -- --watch",
     "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
     "build": "yarn lint && cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
   },

--- a/tests/blobs/CharacterSetExistsPassed_HTML4.html
+++ b/tests/blobs/CharacterSetExistsPassed_HTML4.html
@@ -3,7 +3,7 @@
 <html>
 <head>
   <title>Title</title>
-  <meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1">
+  <meta http-equiv="Content-type" content="text/html;charset=ISO-8859-1">
 </head>
 <body>
 


### PR DESCRIPTION
Looks like Symfony CSSCrawler's `filter()` is case-sensitive. As such, a `http-equiv="Content-type"` (lower-cased second t), while perfectly valid, will yield a false positivity for `CharacterSetExists` rule.