### PR TITLE
Show error when rule failed

### DIFF
--- a/app/Services/Checker.php
+++ b/app/Services/Checker.php
@@ -6,6 +6,7 @@ use App\Crawler;
 use App\Facades\RobotsFile;
 use App\Facades\UrlFetcher;
 use App\Facades\UrlHelper;
+use App\Rules\Levels;
 use App\Rules\Rule;
 use Exception;
 
@@ -64,6 +65,12 @@ class Checker
                     'level'   => $rule->level(),
                 ];
             } catch (Exception $e) {
+                yield [
+                    'passed'  => false,
+                    'message' => "Error checking rule `{$ruleClassName}`.",
+                    'help'    => config('app.debug') ? (string) $e : null,
+                    'level'   => Levels::ERROR,
+                ];
             }
         }
     }


### PR DESCRIPTION
When a rule failes, show an error message that the rule failed. On debug, also show the full exception.
Makes it easier to test and see when something is wrong.

Eg. the Sitemap checker is currently failing.