### PR TITLE
Fix bad url format exception

### DIFF
--- a/app/Rules/NoBrokenLinksOnPage.php
+++ b/app/Rules/NoBrokenLinksOnPage.php
@@ -46,7 +46,7 @@ class NoBrokenLinksOnPage extends Rule
                 $request = new Request('HEAD', $uri);
             } catch (\InvalidArgumentException $e) {
                 // Unable to parse URI exception
-                $fail[] = '* `Bad URL format` - ' . $uri;
+                $fail[] = '* `Bad URL format` - '.$uri;
                 continue;
             }
 

--- a/app/Rules/NoBrokenLinksOnPage.php
+++ b/app/Rules/NoBrokenLinksOnPage.php
@@ -35,12 +35,20 @@ class NoBrokenLinksOnPage extends Rule
     public function check(Crawler $crawler, ResponseInterface $response, UriInterface $uri)
     {
         $requests = [];
+        $ok = 0;
+        $fail = [];
 
         foreach ($crawler->filter('a')->links() as $link) {
             $uri = $link->getUri();
 
-            // Get HEAD to check if exists
-            $request = new Request('HEAD', $uri);
+            try {
+                // Get HEAD to check if exists
+                $request = new Request('HEAD', $uri);
+            } catch (\InvalidArgumentException $e) {
+                // Unable to parse URI exception
+                $fail[] = '* `Bad URL format` - ' . $uri;
+                continue;
+            }
 
             // Strip fragment
             $uri = $request->getUri()->withFragment('');
@@ -57,8 +65,6 @@ class NoBrokenLinksOnPage extends Rule
             return true;
         }
 
-        $ok = 0;
-        $fail = [];
         $pool = new Pool($this->client, $requests, [
             'concurrency' => 5,
             'fulfilled' => function () use (&$ok) {


### PR DESCRIPTION
throwing errors for bad formatted urls

```
"InvalidArgumentException: Unable to parse URI: http:///www.orocommerce.com in /development/laravel/kupo/vendor/guzzlehttp/psr7/src/Uri.php:71Stack trace:#0 /development/laravel/kupo/vendor/guzzlehttp/psr7/src/Request.php(40): GuzzleHttp\Psr7\Uri->__construct('http:///www.oro...')#1 /development/laravel/kupo/app/Rules/NoBrokenLinksOnPage.php(43): GuzzleHttp\Psr7\Request->__construct('HEAD', 'http:///www.oro...')#2 /development/laravel/kupo/app/Services/Checker.php(66): App\Rules\NoBrokenLinksOnPage->check(Object(App\Crawler), Object(GuzzleHttp\Psr7\Response), 'http:///www.oro...')#3 [internal function]: App\Services\Checker->validate('https://ecommwa...')#4 /development/laravel/kupo/routes/api.php(9): iterator_to_array(Object(Generator))#5 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Routing/Route.php(189): App\Providers\RouteServiceProvider->{closure}(Object(App\Http\Requests\CheckRequest), Object(App\Services\Checker))#6 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Routing/Route.php(163): Illuminate\Routing\Route->runCallable()#7 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Routing/Router.php(559): Illuminate\Routing\Route->run()#8 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php(30): Illuminate\Routing\Router->Illuminate\Routing\{closure}(Object(Illuminate\Http\Request))#9 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Routing/Middleware/SubstituteBindings.php(41): Illuminate\Routing\Pipeline->Illuminate\Routing\{closure}(Object(Illuminate\Http\Request))#10 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(148): Illuminate\Routing\Middleware\SubstituteBindings->handle(Object(Illuminate\Http\Request), Object(Closure))#11 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php(53): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(Illuminate\Http\Request))#12 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Routing/Middleware/ThrottleRequests.php(49): Illuminate\Routing\Pipeline->Illuminate\Routing\{closure}(Object(Illuminate\Http\Request))#13 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(148): Illuminate\Routing\Middleware\ThrottleRequests->handle(Object(Illuminate\Http\Request), Object(Closure), '60', '1')#14 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php(53): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(Illuminate\Http\Request))#15 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(102): Illuminate\Routing\Pipeline->Illuminate\Routing\{closure}(Object(Illuminate\Http\Request))#16 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Routing/Router.php(561): Illuminate\Pipeline\Pipeline->then(Object(Closure))#17 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Routing/Router.php(520): Illuminate\Routing\Router->runRouteWithinStack(Object(Illuminate\Routing\Route), Object(Illuminate\Http\Request))#18 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Routing/Router.php(498): Illuminate\Routing\Router->dispatchToRoute(Object(Illuminate\Http\Request))#19 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(174): Illuminate\Routing\Router->dispatch(Object(Illuminate\Http\Request))#20 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php(30): Illuminate\Foundation\Http\Kernel->Illuminate\Foundation\Http\{closure}(Object(Illuminate\Http\Request))#21 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php(46): Illuminate\Routing\Pipeline->Illuminate\Routing\{closure}(Object(Illuminate\Http\Request))#22 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(148): Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode->handle(Object(Illuminate\Http\Request), Object(Closure))#23 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php(53): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(Illuminate\Http\Request))#24 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(102): Illuminate\Routing\Pipeline->Illuminate\Routing\{closure}(Object(Illuminate\Http\Request))#25 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(149): Illuminate\Pipeline\Pipeline->then(Object(Closure))#26 /development/laravel/kupo/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(116): Illuminate\Foundation\Http\Kernel->sendRequestThroughRouter(Object(Illuminate\Http\Request))#27 /development/laravel/kupo/public/index.php(52): Illuminate\Foundation\Http\Kernel->handle(Object(Illuminate\Http\Request))#28 /development/laravel/kupo/server.php(19): require_once('/development/my...')#29 {main}"
```