### PR TITLE
chore(docker): add docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+/node_modules
+/public/storage
+/public/css
+/public/img
+/public/js
+/public/hot
+/storage/*.key
+/vendor
+Homestead.json
+Homestead.yaml
+.env
+/config/customRules.php
+mix-manifest.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:7 as node
+FROM eboraas/laravel
+
+COPY --from=node /usr/local/bin/yarn /usr/local/bin/yarn
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+
+COPY ./ /var/www/laravel
+WORKDIR /var/www/laravel
+
+RUN composer install
+RUN php artisan kupo:init
+
+EXPOSE 8000
+
+CMD php artisan serve --host=0.0.0.0

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,13 @@ php artisan serve
 // kupo should now have been started at http://localhost:8000/
 ```
 
+## Install using Docker
+
+```bash
+docker run -d -p 8000:8000 phanan/kupo
+// kupo should now have been started at http://localhost:8000/
+```
+
 ## Extend
 
 Depending on your needs, you may want to add more rules into kupo. In order to do so, just follow these certain steps:
@@ -52,5 +59,3 @@ If you feel like a certain rule should be added, please contribute! Just fork an
 ## License
 
 MIT © [Phan An](http://phanan.net)
-
-


### PR DESCRIPTION
After merging, steps to add `kupo` to the docker registry:
- go to https://hub.docker.com
- click on `Create` dropdown
- select `Create Automated Build`
- select `Github` then `phanan/kupo`
- Add a description and `Create`
- On the repository go to `Build Settings` and trigger a build
-----
This is using an API which was introduce on docker@17.5.0

Unfortunately at the moment, it's not available as:
- stable: 17.3.1
- rc: 71.5.0